### PR TITLE
fix: ApiError parsing

### DIFF
--- a/lib/api/response_models/api_error.dart
+++ b/lib/api/response_models/api_error.dart
@@ -7,7 +7,7 @@ class ApiError {
         reason = "server_unreachable";
 
   ApiError.fromJson(Map<String, dynamic> json)
-      : message = json["error"],
+      : message = json["message"],
         reason = json["reason"];
 
   Map<String, dynamic> toJson() => {

--- a/test/api/response_models/api_error_test.dart
+++ b/test/api/response_models/api_error_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('from json', () {
-    Map<String, dynamic> json = {"reason": "error", "error": "Message d'erreur"};
+    Map<String, dynamic> json = {"reason": "error", "message": "Message d'erreur"};
     ApiError error = ApiError.fromJson(json);
     expect(error.reason, "error");
     expect(error.message, "Message d'erreur");


### PR DESCRIPTION
There was a problem when receiving errors from the server. The client did not parse properly the errors.
