### PR TITLE
fix: CommonNavigator isCurrent was always returning false

### DIFF
--- a/lib/navigator/common_navigator.dart
+++ b/lib/navigator/common_navigator.dart
@@ -26,8 +26,10 @@ class CommonNavigator {
 
   static bool isCurrent(BuildContext context, RouteBase route) {
     if (route is GoRoute) {
-      return GoRouterState.of(context).fullpath == route.path;
+      return GoRouterState.of(context).location ==
+          GoRouter.of(context).namedLocation(route.name!, params: GoRouterState.of(context).params);
     }
+
     return route.routes.any((subRoute) => CommonNavigator.isCurrent(context, subRoute));
   }
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

There was a problem with the `isCurrent` method of the CommonNavigator which was causing the result to not be correct on nested routes. I changed the check to use namedLocation instead which returns the full path for a route with the necessary parameters.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [x] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes

- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


## Technical highlight/advice
<!-- 
    Is there any complex point you want to highlight ?
    Do you need advice on specific point of your code ?
    Tell us here.
-->
