### PR TITLE
fix: Also logout from the OAuth server

### DIFF
--- a/lib/oauth/oauth_model.dart
+++ b/lib/oauth/oauth_model.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
 import 'package:client_common/oauth/oauth.dart';
+import 'package:client_common/utils/connexion_utils_stub.dart'
+    if (dart.library.io) 'package:client_common/utils/connexion_utils_io.dart'
+    if (dart.library.js) 'package:client_common/utils/connexion_utils_web.dart';
 import 'package:flutter/foundation.dart';
 import 'package:oauth2_client/access_token_response.dart';
 import 'package:oauth2_client/oauth2_helper.dart';
@@ -32,6 +35,20 @@ class OAuthModel extends ChangeNotifier {
     notifyListeners();
 
     return accessToken;
+  }
+
+  Future<void> logout() async {
+    await Future.wait([helper.disconnect(), _oauthDisconnect()]);
+
+    notifyListeners();
+  }
+
+  Future<void> _oauthDisconnect() async {
+    const url =
+        '${const String.fromEnvironment("OAUTH_BASE_URL", defaultValue: 'http://localhost:4444')}/oauth2/sessions/logout';
+
+    var client = createHttpClient();
+    await client.get(Uri.parse(url));
   }
 
   String getPlatformCustomUriScheme() {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
Closes https://github.com/lenra-io/lenra_cli/issues/314

Described in the issue.

## Technical highlight/advice
I've created a new `logout` method in the OAuth model that disconnect the user locally (with the OAuthHelper.disconnect méthod) and from the OAuth Hydra server by calling the /oauth2/sessions/logout endpoint.

## How to test my changes
Described in the issue.

## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


