### PR TITLE
fix: UserResponse can now be null

### DIFF
--- a/lib/api/response_models/user_response.dart
+++ b/lib/api/response_models/user_response.dart
@@ -2,7 +2,7 @@ import 'package:client_common/api/response_models/api_response.dart';
 import 'package:client_common/api/response_models/user.dart';
 
 class UserResponse extends ApiResponse {
-  User user;
+  User? user;
 
-  UserResponse.fromJson(Map<String, dynamic> json, Map<String, String> headers) : user = User.fromJson(json);
+  UserResponse.fromJson(Map<String, dynamic>? json, Map<String, String> headers) : user = json == null ? null : User.fromJson(json);
 }


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
Linked to https://github.com/lenra-io/server/issues/399
<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->

There was a problem when the access token was invalid where the server tried to get the user linked to this access token from the DB but because the access token is invalid, it returned `nil` instead of the user object. 



## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


